### PR TITLE
Replaced check-ram plugin with the lastest version before its deletion.

### DIFF
--- a/plugins/system/check-ram.rb
+++ b/plugins/system/check-ram.rb
@@ -45,12 +45,11 @@ class CheckRAM < Sensu::Plugin::Check::CLI
          default: 5
 
   def run
-    memhash = {}
     meminfo = File.read('/proc/meminfo')
-    meminfo.each_line do |i|
+    memhash = meminfo.each_line.with_object({}) do |i, hash|
       key, val = i.split(':')
       val = val.include?('kB') ? val.gsub(/\s+kB/, '') : val
-      memhash[key.to_s] = val.strip
+      hash[key.to_s] = val.strip
     end
 
     total_ram = (memhash['MemTotal'].to_i << 10) >> 20

--- a/plugins/system/check-ram.rb
+++ b/plugins/system/check-ram.rb
@@ -1,36 +1,63 @@
-#!/usr/bin/env ruby
+#! /usr/bin/env ruby
+#  encoding: UTF-8
 #
-# Check RAM Plugin
+#   check-ram
 #
-
+# DESCRIPTION:
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2012 Sonian, Inc <chefs@sonian.net>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 
 class CheckRAM < Sensu::Plugin::Check::CLI
-
   option :megabytes,
-    :short  => '-m',
-    :long  => '--megabytes',
-    :description => 'Unless --megabytes is specified the thresholds are in percents',
-    :boolean => true,
-    :default => false
+         short: '-m',
+         long: '--megabytes',
+         description: 'Unless --megabytes is specified the thresholds are in percents',
+         boolean: true,
+         default: false
 
   option :warn,
-    :short => '-w WARN',
-    :proc => proc {|a| a.to_i },
-    :default => 10
+         short: '-w WARN',
+         proc: proc(&:to_i),
+         default: 10
 
   option :crit,
-    :short => '-c CRIT',
-    :proc => proc {|a| a.to_i },
-    :default => 5
+         short: '-c CRIT',
+         proc: proc(&:to_i),
+         default: 5
 
   def run
-    total_ram, free_ram = 0, 0
+    memhash = {}
+    meminfo = File.read('/proc/meminfo')
+    meminfo.each_line do |i|
+      key, val = i.split(':')
+      val = val.include?('kB') ? val.gsub(/\s+kB/, '') : val
+      memhash[key.to_s] = val.strip
+    end
 
-    `free -m`.split("\n").drop(1).each do |line|
-      free_ram = line.split[3].to_i if line =~ /^-\/\+ buffers\/cache:/
-      total_ram = line.split[1].to_i if line =~ /^Mem:/
+    total_ram = (memhash['MemTotal'].to_i << 10) >> 20
+    free_ram = if memhash.key?('MemAvailable')
+                 (memhash['MemAvailable'].to_i << 10) >> 20
+               else
+                 ((memhash['MemFree'].to_i + memhash['Buffers'].to_i + memhash['Cached'].to_i) << 10) >> 20
     end
 
     if config[:megabytes]
@@ -40,9 +67,9 @@ class CheckRAM < Sensu::Plugin::Check::CLI
       warning if free_ram < config[:warn]
       ok
     else
-      unknown "invalid percentage" if config[:crit] > 100 or config[:warn] > 100
+      unknown 'invalid percentage' if config[:crit] > 100 || config[:warn] > 100
 
-      percents_left = free_ram*100/total_ram
+      percents_left = free_ram * 100 / total_ram
       message "#{percents_left}% free RAM left"
 
       critical if percents_left < config[:crit]


### PR DESCRIPTION
I copied and pasted the newest version from here: https://github.com/sensu/sensu-community-plugins/blob/e58c1f3ce39c6c0ca271fadd470c04362e92b190/plugins/system/check-ram.rb

The formatting of the alert is fixed, but it does not use `free -m`. It now reads from `/proc/meminfo`. `/proc/meminfo` is the same method used to gather system metrics for graphite. (https://github.com/Invoca/sensu-community-plugins/blob/master/plugins/system/memory-metrics.rb )

